### PR TITLE
README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,20 @@ to look up with default value.
     => nil
     config.lookup!("github.not_there", "default_value")
     => "default_value"
+    
+#### lists
+
+The pattern `add_$key!` can be used to add to or create an array. 
+
+    config = Confstruct::Configuration.new
+    config.add_color! "green"
+    => ["green"]
+    config
+    => {:color=>["green"]}
+    config.add_color! "red"
+    config.color
+    => ["green", "red"]
+    
 
 ### Notes
 


### PR DESCRIPTION
I think RestClient was a poor example for deferred, as deferred blocks are executed on each read, you'd get a brand newly initiaized RestClient instance on every single read, which is probably not what you'd want out of a configuration object. Replaced with much simpler example with just strings. 

Added README sections for lookup! and add_*! features. 

Renamed/reorged the 'extras' section a bit. 
