### PR TITLE
Add dependency status to README, via Gemnasium

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ hash, struct, or block, confstruct aims to provide the flexibility to do things 
 way, while keeping things simple and intuitive.
 
 [![Build Status](https://secure.travis-ci.org/mbklein/confstruct.png)](http://travis-ci.org/mbklein/confstruct)
+[![Dependency Status](https://gemnasium.com/mbklein/confstruct.png)](https://gemnasium.com/mbklein/confstruct)
 
 ## Usage
 


### PR DESCRIPTION
Hi Michael,

I added the dependency status to the README to keep you and your users informed about the state of confstruct's gem dependencies. The idea is that the image will indicate if/when gem versions have moved past your dependency requirements. See [the Rails README](https://github.com/rails/rails#footer) for an example.

If you go and register at [Gemnasium](https://gemnasium.com/), you can also receive free email updates about new gem versions, if you're interested. Full disclosure: I wrote Gemnasium. I hope it helps!

Thank you!
