### PR TITLE
fix issue #11; Ruby 1.9 subclasses of Procs behave differently than in 1.8.

### DIFF
--- a/lib/confstruct/hash_with_struct_access.rb
+++ b/lib/confstruct/hash_with_struct_access.rb
@@ -2,7 +2,11 @@ require 'delegate'
 require 'confstruct/utils'
 
 module Confstruct
-  class Deferred < Proc
+  class Deferred
+    attr_reader :block
+    def initialize &block
+      @block = block
+    end
     def inspect(full=false)
       if full
         super
@@ -77,7 +81,7 @@ module Confstruct
     def [] key
       result = structurize! super(symbolize!(key))
       if result.is_a?(Deferred)
-        result = eval_or_yield self, &result
+        result = eval_or_yield self, &result.block
       end
       result
     end

--- a/spec/confstruct/hash_with_struct_access_spec.rb
+++ b/spec/confstruct/hash_with_struct_access_spec.rb
@@ -181,7 +181,8 @@ describe Confstruct::HashWithStructAccess do
           :default_branch => 'master',
           :regular_proc => lambda { |a,b,c| puts "#{a}: #{b} #{c}" },
           :reverse_url => Confstruct.deferred { self.url.reverse },
-          :upcase_url => Confstruct.deferred { |c| c.url.upcase }
+          :upcase_url => Confstruct.deferred { |c| c.url.upcase },
+          :introspective => Confstruct.deferred { |c| c }
         }
       }
     end
@@ -238,6 +239,10 @@ describe Confstruct::HashWithStructAccess do
       end
       @hwsa.github.local_hello.should == 'Bonjour, Monde!'
       @hwsa.github.local_time.should == 'French Time!'
+    end
+
+    it "should send the confstruct object as a parameter when evaluating the deferred" do
+      @hwsa.github.introspective.should be_a_kind_of(Confstruct::HashWithStructAccess)
     end
       
   end


### PR DESCRIPTION
Less elegant, but this seems to do the trick..
