### PR TITLE
#lookup! should accept symbols

### DIFF
--- a/lib/confstruct/hash_with_struct_access.rb
+++ b/lib/confstruct/hash_with_struct_access.rb
@@ -152,7 +152,7 @@ module Confstruct
     
     def lookup! key_path, fallback = nil
       val = self
-      keys = key_path.split(/\./)
+      keys = key_path.to_s.split(/\./)
       keys.each do |key|
         return fallback if val.nil?
         if val.respond_to?(:has_key?) and val.has_key?(key.to_sym)

--- a/spec/confstruct/hash_with_struct_access_spec.rb
+++ b/spec/confstruct/hash_with_struct_access_spec.rb
@@ -73,10 +73,14 @@ describe Confstruct::HashWithStructAccess do
     
     it "should properly respond to #lookup!" do
       @hwsa.lookup!('github.url').should == @hash[:github][:url]
+      @hwsa.lookup!(:'github.url').should == @hash[:github][:url]
       @hwsa.lookup!('github.foo.bar.baz',:default).should == :default
+      @hwsa.lookup!(:'github.foo.bar.baz',:default).should == :default
       @hwsa.lookup!('github.foo.bar.baz').should be_nil
+      @hwsa.lookup!(:'github.foo.bar.baz').should be_nil
       @hwsa.github.quux = nil
       @hwsa.lookup!('github.quux',:default).should be_nil
+      @hwsa.lookup!(:'github.quux',:default).should be_nil
     end
     
     it "should provide introspection" do


### PR DESCRIPTION
lookup! fails if you give a symbol key. This is unexpected as [] accepts symbols.
