### PR TITLE
demo odd problem in 2.1

### DIFF
--- a/spec/confstruct/weird_lambda_spec.rb
+++ b/spec/confstruct/weird_lambda_spec.rb
@@ -1,0 +1,17 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe "lambda is weird" do
+
+  it "should allow lambdas" do
+    conf = Confstruct::Configuration.new
+
+    conf.configure do      
+      my_key lambda {|a| a}  
+    end 
+        
+    puts conf.inspect
+
+    expect(conf.my_key).to be_kind_of(Proc)    
+  end
+
+end


### PR DESCRIPTION
Okay, this PR is just a failing test. 

This is really weird. We want to be able to set lambdas as values. In 1.9.3, this works:

~~~ruby
conf = Confstruct::Configuration.new

conf.configure do      
   my_key lambda {|a| a}  
end 
~~~

And results in a Configuration object that looks like this: 

~~~ruby
{:my_key=>#<Proc:0x007fad04901d08@./spec/confstruct/weird_lambda_spec.rb:9 (lambda)>}
~~~

Great, just what we wanted. 

In ruby 2.1.3, it fails, and results in a Configuration object that looks like this:

~~~ruby
{:lambda=>{}, :my_key=>{}}
~~~

What's going on is somehow the word 'lambda', is being caught by the `method_missing` on Confstruct::Configuration, instead of being interpreted as a ruby keyword as it should be. 

Why is a ruby keyword somehow going to method_missing but only in ruby 2.1? Arghhh.  I wonder if it's a bug in ruby 2.1, or a documented change in behavior of some kind -- it would be nice to reduce this to a test case in terms of pure ruby to file a ruby issue on, but it took me hours just to figure out what was going on in terms of Confstruct. 

I guess the workaround is using Proc.new instead, which works.  