### PR TITLE
Restore canonical keys to Symbol not String

### DIFF
--- a/lib/confstruct/hash_with_struct_access.rb
+++ b/lib/confstruct/hash_with_struct_access.rb
@@ -39,7 +39,15 @@ module Confstruct
     attr_accessor :default_values
     @default_values = {}
     
-    
+    # Hashie::Mash normally standardizes all keys as strings
+    # We can override this method to standardize as symbols either,
+    # for backwards-compat with previous Confstruct. 
+    # Turns out changing this effects things like merges into ordinary hashes
+    # that client code might be doing, and makes a backward compat
+    # nightmare. 
+    def convert_key(key)
+      key.to_sym
+    end
 
     def self.from_hash(hash)
       self.new(hash)

--- a/spec/confstruct/configuration_spec.rb
+++ b/spec/confstruct/configuration_spec.rb
@@ -22,10 +22,10 @@ describe Confstruct::Configuration do
   context "default values" do
     before :all do
       @defaults = { 
-        'project' => 'confstruct', 
-        'github' => { 
-          'url' => 'http://www.github.com/mbklein/confstruct',
-          'branch' => 'master'
+        :project => 'confstruct', 
+        :github => { 
+          :url => 'http://www.github.com/mbklein/confstruct',
+          :branch => 'master'
         }
       }
     end
@@ -56,18 +56,18 @@ describe Confstruct::Configuration do
   context "configuration" do
     before :all do
       @defaults = { 
-        'project' => 'confstruct', 
-        'github' => { 
-          'url' => 'http://www.github.com/mbklein/confstruct',
-          'branch' => 'master'
+        :project => 'confstruct', 
+        :github => { 
+          :url => 'http://www.github.com/mbklein/confstruct',
+          :branch => 'master'
         }
       }
       
       @configured = { 
-        'project' => 'other-project', 
-        'github' => { 
-          'url' => 'http://www.github.com/mbklein/other-project',
-          'branch' => 'master'
+        :project => 'other-project', 
+        :github => { 
+          :url => 'http://www.github.com/mbklein/other-project',
+          :branch => 'master'
         }
       }
     end

--- a/spec/confstruct/hash_with_struct_access_spec.rb
+++ b/spec/confstruct/hash_with_struct_access_spec.rb
@@ -170,7 +170,7 @@ describe Confstruct::HashWithStructAccess do
           psmith :chum
         end
       end
-      @hwsa.github.roles.should == [{'jeeves' => :valet}, {'wooster' => :dolt}, {'psmith' => :chum}]
+      @hwsa.github.roles.should == [{:jeeves => :valet}, {:wooster => :dolt}, {:psmith => :chum}]
       @hwsa.github.roles.first.jeeves.should == :valet
     end
     

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,6 @@ end
 
 RSpec::Matchers.define :match_indifferently do |expected|
   match do |actual|
-    IndifferentHashieHash.new(actual) ==  IndifferentHashieHash.new(expected)
+    IndifferentHashieHash.new(actual.to_hash) ==  IndifferentHashieHash.new(expected.to_hash)
   end
 end


### PR DESCRIPTION
Prior to the Hashie::Mash integration in 1.0.0, Confstruct's
internal keys were canonicalized to symbols, as evidence if
you called #keys on one of em.

Hashie::Mash uses Strings instead, so with the Hashie::Mash
merge they used Strings instead.  At first I thought, eh, this
isn't a big deal, who goes looking at the #keys of their
configuration objects much?

But I realized, after trying to incorporate it into my already
existing app, that it ends up effecting a lot more -- such
as `ordinary_hash.merge(confstruct_hash)`. Ends up creating
all sorts of hard to deal with byproduct changes.

Fortunately, Hashie::Mash is written well and allows us
to switch (back) to Symbols by overriding one simple DRY
convert_keys method. So we do so, restoring backwards compat
with previous versions of Confstruct.

Suggest release as 1.0.1.