### PR TITLE
Add missing structurize method.

### DIFF
--- a/lib/confstruct/hash_with_struct_access.rb
+++ b/lib/confstruct/hash_with_struct_access.rb
@@ -122,6 +122,14 @@ module Confstruct
       end
       return val
     end
+
+    def self.structurize hash
+      result = hash
+      if result.is_a?(Hash) and not result.is_a?(HashWithStructAccess)
+        result = HashWithStructAccess.new(result)
+      end
+      result
+    end
     
     def method_missing sym, *args, &block
       name = sym.to_s.chomp('=').to_sym
@@ -134,7 +142,7 @@ module Confstruct
           raise TypeError, "Cannot #add! to a #{self[name].class}"
         end
         if args.length > 0
-          local_args = args.collect { |a| structurize! a }
+          local_args = args.collect { |a| self.class.structurize a }
           result = self[name].push *local_args
         elsif block_given?
           result = HashWithStructAccess.new


### PR DESCRIPTION
I can't explain why this ever worked without it. We called a
structurize! method that we removed from Confstruct in 1.0... but
somehow our tests were still passing. Until Hashie 3.4.3, when
they stopped. I think maybe a bug in previous hashie hid our own
bug. I don't entirely understand it, and probably should add more tests,
but just adding enough to pass now.