### PR TITLE
update to rspec 3

### DIFF
--- a/confstruct.gemspec
+++ b/confstruct.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency "hashie", "~> 3.3"
-  
+
   s.add_development_dependency "rake", ">=0.8.7"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "rdoc"
-  s.add_development_dependency "rspec", "~> 2.99"
+  s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "yard"
-  
+
 end

--- a/spec/confstruct/configuration_spec.rb
+++ b/spec/confstruct/configuration_spec.rb
@@ -138,7 +138,7 @@ describe Confstruct::Configuration do
     
     it "should call #after_config! when configuration is complete" do
       postconfigurator = double('after_config!')
-      postconfigurator.should_receive(:configured!).once.with(@config)
+      expect(postconfigurator).to receive(:configured!).once.with(@config)
       def @config.after_config! obj
         obj.project.should == 'other-project'
         obj.mock.configured!(obj)

--- a/spec/confstruct/hash_with_struct_access_spec.rb
+++ b/spec/confstruct/hash_with_struct_access_spec.rb
@@ -241,8 +241,8 @@ describe Confstruct::HashWithStructAccess do
     it "should handle i18n translations" do
       t = Time.now
       I18n = RSpec::Mocks::Double.new('I18n')
-      I18n.should_receive(:translate).with('Hello, World!').at_least(:once).and_return('Bonjour, Monde!')
-      I18n.should_receive(:localize).with(t).at_least(:once).and_return('French Time!')
+      expect(I18n).to receive(:translate).with('Hello, World!').at_least(:once).and_return('Bonjour, Monde!')
+      expect(I18n).to receive(:localize).with(t).at_least(:once).and_return('French Time!')
       @hwsa.github do
         hello 'Hello, World!'
         time t

--- a/spec/confstruct/utils_spec.rb
+++ b/spec/confstruct/utils_spec.rb
@@ -6,15 +6,15 @@ describe "Kernel.eval_or_yield" do
   end
   
   it "should instance_eval when the block takes no params" do
-    @obj.should_receive(:test).and_return('OK')
-    eval_or_yield(@obj) { 
+    expect(@obj).to receive(:test).and_return('OK')
+    eval_or_yield(@obj) {
       self.should_not == @obj
       self.test.should == 'OK'
     }
   end
   
   it "should yield when the block takes a param" do
-    @obj.should_receive(:test).and_return('OK')
+    expect(@obj).to receive(:test).and_return('OK')
     eval_or_yield(@obj) { |o|
       self.should_not == @obj
       o.should == @obj

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 require 'bundler/setup'
 require 'rspec'
-require 'rspec/autorun'
 
 require 'rubygems'
 require 'confstruct'
@@ -12,7 +11,10 @@ require 'simplecov'
 SimpleCov.start
 
 RSpec.configure do |config|
-  
+  config.expect_with :rspec do |expectations|
+    # our specs written a long time ago still use :should syntax
+    expectations.syntax = [:should, :expect]
+  end
 end
 
 


### PR DESCRIPTION
Rspec2 is incompatible with latest versions of rake, so we wanted to update to rspec 3. Tests all pass with rspec 3, but with some deprecation notices. Made the minimal changes to avoid rspec 3 deprecation warnings too.

There's no CI configured here, but I ran tests locally, they passed:

```
$ bundle exec rake
/Users/jrochkind/.rubies/ruby-2.6.6/bin/ruby -I/Users/jrochkind/.gem/ruby/2.6.6/gems/rspec-core-3.10.1/lib:/Users/jrochkind/.gem/ruby/2.6.6/gems/rspec-support-3.10.2/lib /Users/jrochkind/.gem/ruby/2.6.6/gems/rspec-core-3.10.1/exe/rspec --pattern ./spec/\*\*/\*_spec.rb
...............*.............*...........*....

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Confstruct::HashWithStructAccess should respond to #ordered?
     # we no longer implement ordered?, not needed in ruby 1.9+
     # ./spec/confstruct/hash_with_struct_access_spec.rb:12

  2) Confstruct::HashWithStructAccess data manipulation should fail on other method signatures
     # I don't understand what this is supposed to do and why
     # ./spec/confstruct/hash_with_struct_access_spec.rb:161

  3) Confstruct::HashWithStructAccess delegation should gracefully handle being extended
     # probably won't fix due to the unpredictable way ActiveSupport injects #presence()
     # ./spec/confstruct/hash_with_struct_access_spec.rb:271


Finished in 0.04667 seconds (files took 0.27314 seconds to load)
46 examples, 0 failures, 3 pending

Coverage report generated for RSpec to /Users/jrochkind/code/confstruct/coverage. 293 / 300 LOC (97.67%) covered.
```