### PR TITLE
Allow hashie 4

### DIFF
--- a/confstruct.gemspec
+++ b/confstruct.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'active_support'
   end
 
-  s.add_dependency "hashie", "~> 3.3"
+  s.add_dependency "hashie", ">= 3.3", "< 5"
 
   s.add_development_dependency "rake", ">=0.8.7"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Tests all pass, is that enough to be sure that hashie 4 is just fine? Gemspec still allows hashie 3 too, it doesn't force an app to update. It just allows an app to use hashie 4 instead.

I have an old gem that's still using confstruct, and I didn't wnat using my gem to force an app to use hashie 3, that might be incompatible with other dependencies. That's the motivation here. My gem does have it's own tests pass against a confstruct using hashie 4.

If we merge this, I'd like to do a confstruct release. Since it doesn't force an upgrade to hashie 4, probably does not need to be a major version release, just minor?

Passes tests locally for me:

```
$ bundle info hashie
  * hashie (4.1.0)
	Summary: Your friendly neighborhood hash library.
	Homepage: https://github.com/hashie/hashie
	Path: /Users/jrochkind/.gem/ruby/2.6.6/gems/hashie-4.1.0

$ bundle exec rake
/Users/jrochkind/.rubies/ruby-2.6.6/bin/ruby -I/Users/jrochkind/.gem/ruby/2.6.6/gems/rspec-core-3.10.1/lib:/Users/jrochkind/.gem/ruby/2.6.6/gems/rspec-support-3.10.2/lib /Users/jrochkind/.gem/ruby/2.6.6/gems/rspec-core-3.10.1/exe/rspec --pattern ./spec/\*\*/\*_spec.rb
...............*.............*...........*....

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Confstruct::HashWithStructAccess should respond to #ordered?
     # we no longer implement ordered?, not needed in ruby 1.9+
     # ./spec/confstruct/hash_with_struct_access_spec.rb:12

  2) Confstruct::HashWithStructAccess data manipulation should fail on other method signatures
     # I don't understand what this is supposed to do and why
     # ./spec/confstruct/hash_with_struct_access_spec.rb:161

  3) Confstruct::HashWithStructAccess delegation should gracefully handle being extended
     # probably won't fix due to the unpredictable way ActiveSupport injects #presence()
     # ./spec/confstruct/hash_with_struct_access_spec.rb:271


Finished in 0.0412 seconds (files took 0.2689 seconds to load)
46 examples, 0 failures, 3 pending

Coverage report generated for RSpec to /Users/jrochkind/code/confstruct/coverage. 293 / 300 LOC (97.67%) covered.
```